### PR TITLE
v1.2.0

### DIFF
--- a/.github/workflows/ArtifactsUpload.yml
+++ b/.github/workflows/ArtifactsUpload.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  Build:
-    name: Upload artifact
+  Build-1:
+    name: Build 1 - Upload artifact
     runs-on: ubuntu-24.04
 
     steps:
@@ -19,38 +19,209 @@ jobs:
           mkdir -p bin
           echo "Program $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > bin/program.py
           chmod u+x bin/program.py
+          echo "Tool $(date --utc '+%d.%m.%Y - %H:%M:%S')"      > bin/tool.py
+          chmod g+x bin/tool.py
           
           mkdir -p lib
-          echo "Library $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/common.py
+          echo "Library 1 $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/common.py
           chmod +x lib/common.py
+          echo "Library 2 $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/shared.py
+          chmod +x lib/shared.py
+          
+          mkdir -p lib/gui
+          echo "Library 3 $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/gui/main.py
+          chmod +x lib/gui/main.py
+          echo "Library 4 $(date --utc '+%d.%m.%Y - %H:%M:%S')"   > lib/gui/dialog.py
+          chmod +x lib/gui/dialog.py
 
       - name: 🔎 Inspect directory structure
         run: |
           tree .
 
-      - name: 📤 Upload artifact
+      - name: 📤 Upload artifact 'github-release'
         uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
         with:
-          name: release
+          name: github-release
           path: |
             document1.txt
             *.log
-            bin/
-            lib/*.py
-#          if-no-files-found: error
-#          retention-days: 1
+            bin/*.py
+            lib/
 
-  Verify:
+      - name: 📤 Upload artifact 'pyTooling-release'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-release
+          path: |
+            document1.txt
+            *.log
+            bin/*.py
+            lib/
+
+      - name: 📤 Upload artifact 'pyTooling-lib'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-lib
+          working-directory: lib
+          path: |
+            **/*.py
+
+      - name: 📤 Upload artifact 'github-single-file'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-single-file
+          path: |
+            document1.txt
+
+      - name: 📤 Upload artifact 'pyTooling-single-file'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-single-file
+          path: |
+            document1.txt
+
+      - name: 📤 Upload artifact 'github-single-file-in-directory'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-single-file-in-directory
+          path: |
+            bin/program.py
+
+      - name: 📤 Upload artifact 'pyTooling-single-file-in-directory'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-single-file-in-directory
+          path: |
+            bin/program.py
+
+      - name: 📤 Upload artifact 'github-double-file-in-directory'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-double-file-in-directory
+          path: |
+            bin/program.py
+            bin/tool.py
+
+      - name: 📤 Upload artifact 'pyTooling-double-file-in-directory'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-double-file-in-directory
+          path: |
+            bin/program.py
+            bin/tool.py
+
+      - name: 📤 Upload artifact 'github-triple-file-in-directory'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-triple-file-in-directory
+          path: |
+            lib/common.py
+            lib/gui/main.py
+            lib/gui/dialog.py
+
+      - name: 📤 Upload artifact 'pyTooling-triple-file-in-directory'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-triple-file-in-directory
+          path: |
+            lib/common.py
+            lib/gui/main.py
+            lib/gui/dialog.py
+
+      - name: 📤 Upload artifact 'github-double-file-in-deep-directory'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-double-file-in-deep-directory
+          path: |
+            lib/gui/main.py
+            lib/gui/dialog.py
+
+      - name: 📤 Upload artifact 'pyTooling-double-file-in-deep-directory'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-double-file-in-deep-directory
+          path: |
+            lib/gui/main.py
+            lib/gui/dialog.py
+
+      - name: 📤 Upload artifact 'github-single-directory'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-single-directory
+          path: |
+            bin
+
+      - name: 📤 Upload artifact 'pyTooling-single-directory'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-single-directory
+          path: |
+            bin
+
+      - name: 📤 Upload artifact 'github-double-directory'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-double-directory
+          path: |
+            bin
+            lib
+
+      - name: 📤 Upload artifact 'pyTooling-double-directory'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-double-directory
+          path: |
+            bin
+            lib
+
+      - name: 📤 Upload artifact 'github-unpredictable-wildcard'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: github-unpredictable-wildcard
+          path: |
+            lib/gui/main.py
+            lib/gui/dialog.py
+            *.foo
+
+      - name: 📤 Upload artifact 'pyTooling-unpredictable-wildcard'
+        uses: pyTooling/upload-artifact@dev
+        continue-on-error: true
+        with:
+          name: pyTooling-unpredictable-wildcard
+          path: |
+            lib/gui/main.py
+            lib/gui/dialog.py
+            *.foo
+
+  Verify-0:
     name: Verify artifact content
     runs-on: ubuntu-24.04
     needs:
-      - Build
+      - Build-1
 
     steps:
       - name: 📥 Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: release
+          name: github-release
 
       - name: 🔎 Inspect downloaded artifact content
         run: |
@@ -161,3 +332,293 @@ jobs:
           else
             echo -e "${ANSI_LIGHT_GREEN}No errors found.${ANSI_NOCOLOR}"
           fi
+
+  Inspect-1:
+    name: Inspect single file
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-single-file
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Inspect-2:
+    name: Inspect single file in directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-single-file-in-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Inspect-3:
+    name: Inspect double file in directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-double-file-in-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Inspect-4:
+    name: Inspect triple file in directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-triple-file-in-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Inspect-5:
+    name: Inspect double file in deep directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-double-file-in-deep-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Inspect-6:
+    name: Inspect single directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-single-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Inspect-7:
+    name: Inspect double directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-double-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Inspect-8:
+    name: Inspect Unpredictable Wildcard
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-unpredictable-wildcard
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tree .
+
+  Verify-1:
+    name: Verify single file
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-single-file
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-2:
+    name: Verify single file in directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-2
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-single-file-in-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-3:
+    name: Verify double file in directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-3
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-double-file-in-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-4:
+    name: Verify triple file in directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-4
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-triple-file-in-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-5:
+    name: Verify double file in deep directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-5
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-double-file-in-deep-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-6:
+    name: Verify single directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-6
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-single-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-7:
+    name: Verify double directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-7
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-double-directory
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-8:
+    name: Verify Unpredictable Wildcard
+    runs-on: ubuntu-24.04
+    needs:
+      - Inspect-8
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-unpredictable-wildcard
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .
+
+  Verify-9:
+    name: Verify lib directory
+    runs-on: ubuntu-24.04
+    needs:
+      - Build-1
+
+    steps:
+      - name: 📥 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pyTooling-lib
+
+      - name: 🔎 Inspect extracted tarball
+        run: |
+          tar -xf "__upload_artifact__.tar"
+          rm __upload_artifact__.tar
+          tree .

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,17 @@ inputs:
     type: string
     required: false
     default: 'artifact'
+  working-directory:
+#    description:
+    type: string
+    required: false
+    default: ''
   path:
     description: |
       A file, directory or wildcard pattern that describes what to upload
       Required.
     type: string
+    required: true
   if-no-files-found:
     description: |
       The desired behavior if no files are found using the provided path.
@@ -61,7 +67,7 @@ inputs:
     type: boolean
     required: false
     default: false
-  temp_tarball:
+  tarball-name:
     type: string
     required: false
     default: '__upload_artifact__.tar'
@@ -89,25 +95,54 @@ runs:
 
         ANSI_LIGHT_RED="\e[91m"
         ANSI_LIGHT_GREEN="\e[92m"
+        ANSI_CYAN="\e[36m"
         ANSI_NOCOLOR="\e[0m"
 
+        if [[ "${{ inputs.working-directory }}" != "" ]]; then
+          echo -n "Changing artifact root directory to '${{ inputs.working-directory }}' ... "
+          if [[ -d "${{ inputs.working-directory }}" ]]; then
+            pushd "${{ inputs.working-directory }}" > /dev/null
+            if [[ $? -ne 0 ]]; then
+              echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+              exit 1
+            else
+              echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+              echo "tar_directory=${{ inputs.working-directory }}/" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo -e "echo -e ${ANSI_LIGHT_RED}[NO DIRECTORY]${ANSI_NOCOLOR}"
+            exit 1
+          fi
+        else
+          echo "tar_directory=" >> $GITHUB_OUTPUT
+        fi
+
+        echo -n "Resolving provided file patterns ... "
         PATTERNS=()
         while IFS=$'\r\n' read -r pattern; do
           # skip empty or comment lines
           [[ "${pattern}" == "" || "${pattern:0:1}" == "#" ]] && continue
 
-          PATTERNS+=($pattern)
+          PATTERNS+=("$pattern")
         done <<<'${{ inputs.path }}'
+        echo -e "${ANSI_LIGHT_GREEN}[DONE]${ANSI_NOCOLOR}"
         
-        # echo "PATTERNS: ${PATTERNS[@]}"
+        print_files_unique() {
+          for i in "$@"; do
+            compgen -G "$i" || true
+          done | sort | uniq
+        }
         
         echo -n "Creating temporary tarball ... "
-        tar -cf "${{ inputs.temp_tarball }}" "${PATTERNS[@]}"
+        tar -cf "${{ inputs.tarball-name }}" --verbatim-files-from --files-from <(print_files_unique "${PATTERNS[@]}")
         if [[ $? -ne 0 ]]; then
           echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+          exit 1
         else
           echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
         fi
+        
+        echo -e "${ANSI_CYAN}Files collected: $(tar -tf '${{ inputs.tarball-name }}' | wc -l)${ANSI_NOCOLOR}"
 
     # https://github.com/actions/upload-artifact
     - name: Upload artifact
@@ -115,8 +150,12 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
-        path: ${{ inputs.temp_tarball }}
+        path: ${{ steps.prepare.outputs.tar_directory }}${{ inputs.tarball-name }}
+        if-no-files-found: ${{ inputs.if-no-files-found }}
+        retention-days: ${{ inputs.retention-days }}
+        compression-level: ${{ inputs.compression-level }}
         overwrite: ${{ inputs.overwrite }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}
 
     - name: Remove temporary tarball
       id: cleanup
@@ -129,7 +168,7 @@ runs:
         ANSI_NOCOLOR="\e[0m"
         
         echo -n "Removing temporary tarball ... "
-        rm -f "${{ inputs.temp_tarball }}"
+        rm -f "${{ steps.prepare.outputs.tar_directory }}${{ inputs.tarball-name }}"
         if [[ $? -ne 0 ]]; then
           echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
         else


### PR DESCRIPTION
# New Features

* Added parameter `working-directory`, so the root of the artifacts content can be specified.
* Report number of collected files in the tarball.


# Changes

* Renamed parameter `temp_tarball` to `tarball-name`.
* Improved pattern handling (e.g. avoid duplicate files in the tarball).


# Bug Fixes

* v1.1.0 introduced all parameters supported by `actions/upload-artifact`, but most were not forwarded to the inner usage of `actions/upload-artifact`. This is now fixed.


# Unit Tests

* Added lots of tests to compare the behavior of `actions/upload-artifact` and `pyTooling/upload-artifact`.  
  &rArr; `actions/upload-artifact` is removing the common prefix of all files in the artifact. This is a very bad behavior!


# Incompatibility to `upload-artifacts`

`actions/upload-artifact` removes the common prefix of all files in the artifact.
* This behavior is against the artifact idea to transport a directory from job to job.
  1. The directory structure is modified, because the created zip file swallows the common parent directories.
  2. File permissions are ignored (e.g. executable bit of compiled binaries like from GCC).
* Including or excluding certain files to/from the artifact has an impact on the artifact's internal directory structure. Thus, also how it's restored in the target job.

It was decided to NOT support this behavior. `pyTooling/upload-artifact` offers a `working-directory` input parameter to specify the root of the artifact content. All `path` patterns are relative from there.


------
/cc @skoehler