### PR TITLE
v1.3.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+# end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 2
+tab_width = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Maintain GitHub Action runners
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: dev
+    commit-message:
+      prefix: "[Dependabot]"
+    labels:
+      - Dependencies
+    assignees:
+      - Paebbels
+    reviewers:
+      - Paebbels
+    schedule:
+      interval: "daily"    # Checks on Monday trough Friday.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# New Features
+
+* tbd
+* tbd
+
+# Changes
+
+* tbd
+* tbd
+
+# Bug Fixes
+
+* tbd
+* tbd
+
+# Documentation
+
+* tbd
+* tbd
+
+# Unit Tests
+
+* tbd
+* tbd
+
+----------
+# Related Issues and Pull-Requests
+
+* tbd
+* tbd

--- a/.github/workflows/ArtifactsUpload.yml
+++ b/.github/workflows/ArtifactsUpload.yml
@@ -1,3 +1,19 @@
+# The MIT License (MIT)
+#
+# Copyright © 2024 The pyTooling Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 name: Verification of Preserving Artifact Upload
 
 on:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,16 @@
+# The MIT License (MIT)
+
+Copyright © 2024 The pyTooling Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,96 @@
-# Preserving Artifact Upload Action
+# File Permission Preserving Artifact Upload Action
 
-Upload artifacts and preserve file attributes like file permissions.
-
+This composite action, based on [`actions/upload-artifact`](https://github.com/actions/upload-artifact) and packaging
+the artifact's content in a tarball, will preserve file attributes like **file permissions**. This essential capability
+is not implemented by GitHub until now (requested on [05.12.2019](https://github.com/actions/upload-artifact/issues/38))
+and still delayed and/or refused? to be implemented in the future. According to GitHub, the internal API doesn't allow
+the implementation of such a feature, but this actions is demonstrating a working solution.
 
 **Based on:**
  * [actions/upload-artifact#38 - upload-artifact does not retain artifact permissions (08. Sep. 2024)](https://github.com/actions/upload-artifact/issues/38#issuecomment-2336484584)
  * [Gist: 
 rcdailey/download-tar-action.yml](https://gist.github.com/rcdailey/cd3437bb2c63647126aa5740824b2a4f)
 
+
+## Usage
+
+```yaml
+jobs:
+  MyJob:
+    steps:
+      - name: 📤 Upload artifact 'binaries'
+        uses: pyTooling/upload-artifact@v4
+        with:
+          name: binaries
+          working-directory: build
+          path: |
+            bin
+            lib
+            
+      - name: 📤 Upload artifact 'logfiles'
+        uses: pyTooling/upload-artifact@v4
+        with:
+          name: logfiles
+          path: |
+            *.report
+            build/*.log
+```
+
+| Parameter              | Required | Default             | Description                                                                                                                                                                                                                                                                          |
+|------------------------|:--------:|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                 |    no    | `'artifact'`        | Name of the artifact to upload.                                                                                                                                                                                                                                                      |
+| `working-directory`    |    no    | `''`                |                                                                                                                                                                                                                                                                                      |
+| `path`                 |   yes    |                     | A list of files, directories or wildcard patterns that describes what to upload.                                                                                                                                                                                                     |
+| `if-no-files-found`    |    no    | `'warn'`            | The desired behavior if no files are found using the provided path. <br/> Available Options:<br/>  warn: Output a warning but do not fail the action<br/>  error: Fail the action with an error message<br/>  ignore: Do not output any warnings or errors, the action does not fail |
+| `retention-days`       |    no    | repository settings | Duration after which artifact will expire in days. 0 means using default retention. <br/> Minimum 1 day.<br/> Maximum 90 days unless changed from the repository settings page.                                                                                                      |
+| `compression-level`    |    no    | `6`                 | The level of compression for Zlib to be applied to the artifact archive.<br/> The value can range from 0 to 9.<br/> For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.                                                    |
+| `overwrite`            |    no    | `false`             | If true, an artifact with a matching name will be deleted before a new one is uploaded.<br/> If false, the action will fail if an artifact for the given name already exists.<br/> Does not fail if the artifact does not exist.                                                     |
+| `include-hidden-files` |    no    | `false`             | Whether to include hidden files in the provided path in the artifact.<br/> The file contents of any hidden files in the path should be validated before enabled this to avoid uploading sensitive information.                                                                       |
+| `tarball-name`         |    no    | [^1]                |                                                                                                                                                                                                                                                                                      |
+
+[^1]: `'__pyTooling_upload_artifact__.tar'`
+
+
 ## Fixed behavior compared to `actions/upload-artifact`
 
-*tbd*
+1. **Do preserve file permissions**  
+   The artifact's content is collected in a tarball, which allows preserving file attributes like file permissions.
+2. **Don't remove common prefix from files**  
+   `actions/upload-artifact` removes the common prefix from all files before storing in an artifact. This is not a
+   well-defined behavior. Slightly changing the list of collected files might drastically change the directory structure
+   of the artifact.  
+   This action defines a root directory from where the content of the tarball is constructed. This is independent of the
+   list of provided file patterns.
 
-1. Preserve file permissions
-2. Defined root directory from where the content of the tarball is constructed.
 
 ## Limitations of `tar`
 
-### On Linux
+This action uses `tar` as provided by the GitHub runner's operating system images.
 
-*tbd*
+### On Linux (GNU tar)
+
+To ensure files starting with a dash aren't considered command line options to `tar`, it's called with
+`--verbatim-files-from` option.
+
+### On macOS (BSD tar)
+
+BSD tar doesn't support a `--verbatim-files-from` option. Thus, files starting with a dash might be interpreted by `tar`
+as a command line option.
+
+> **-T filename**, **--files-from filename**  
+> In `x` or `t` mode, tar will read the list of names to be extracted from filename. In `c` mode, tar will read names to
+> be archived from filename. The special name `-C` on a line by itself will cause the current directory to be changed to
+> the directory specified on the following line. Names are terminated by newlines unless `--null` is specified. Note
+> that `--null` also disables the special handling of lines containing `-C`.  
+> Note: If you are generating lists of files using `find(1)`, you probably want to use `-n` as well.
+> 
+> Source: https://man.freebsd.org/cgi/man.cgi?tar(1)
 
 
-### On macOS
+### On Windows (GNU tar)
 
-*tbd*
-
-
-### On Windows
-
-*tbd*
+To ensure files starting with a dash aren't considered command line options to `tar`, it's called with
+`--verbatim-files-from` option.
 
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
-# File Permission Preserving Artifact Upload Action
+# Artifact Upload Action with File Permission Preservation
 
 This composite action, based on [`actions/upload-artifact`](https://github.com/actions/upload-artifact) and packaging
 the artifact's content in a tarball, will preserve file attributes like **file permissions**. This essential capability
 is not implemented by GitHub until now (requested on [05.12.2019](https://github.com/actions/upload-artifact/issues/38))
 and still delayed and/or refused? to be implemented in the future. According to GitHub, the internal API doesn't allow
 the implementation of such a feature, but this actions is demonstrating a working solution.
-
-**Based on:**
- * [actions/upload-artifact#38 - upload-artifact does not retain artifact permissions (08. Sep. 2024)](https://github.com/actions/upload-artifact/issues/38#issuecomment-2336484584)
- * [Gist: 
-rcdailey/download-tar-action.yml](https://gist.github.com/rcdailey/cd3437bb2c63647126aa5740824b2a4f)
 
 
 ## Usage
@@ -36,6 +31,9 @@ jobs:
             build/*.log
 ```
 
+
+### Input Parameters
+
 | Parameter              | Required | Default             | Description                                                                                                                                                                                                                                                                          |
 |------------------------|:--------:|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `name`                 |    no    | `'artifact'`        | Name of the artifact to upload.                                                                                                                                                                                                                                                      |
@@ -49,6 +47,14 @@ jobs:
 | `tarball-name`         |    no    | [^1]                |                                                                                                                                                                                                                                                                                      |
 
 [^1]: `'__pyTooling_upload_artifact__.tar'`
+
+
+### Output Parameters
+
+| Parameter      | Description                                                                                                                                                                                                                                                                                    |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `artifact-id`  | GitHub ID of an Artifact, can be used by the REST API                                                                                                                                                                                                                                          |
+| `artifact-url` | URL to download an Artifact. Can be used in many scenarios such as linking to artifacts in issues or pull requests. Users must be logged-in in order for this URL to work. This URL is valid as long as the artifact has not expired or the artifact, run or repository have not been deleted. |
 
 
 ## Fixed behavior compared to `actions/upload-artifact`
@@ -69,12 +75,13 @@ This action uses `tar` as provided by the GitHub runner's operating system image
 
 ### On Linux (GNU tar)
 
-To ensure files starting with a dash aren't considered command line options to `tar`, it's called with
+To ensure files starting with a dash aren't considered command line options to `tar`, `tar` is called with
 `--verbatim-files-from` option.
+
 
 ### On macOS (BSD tar)
 
-BSD tar doesn't support a `--verbatim-files-from` option. Thus, files starting with a dash might be interpreted by `tar`
+⚠ BSD tar doesn't support a `--verbatim-files-from` option. Thus, files starting with a dash might be interpreted by `tar`
 as a command line option.
 
 > **-T filename**, **--files-from filename**  
@@ -89,7 +96,7 @@ as a command line option.
 
 ### On Windows (GNU tar)
 
-To ensure files starting with a dash aren't considered command line options to `tar`, it's called with
+To ensure files starting with a dash aren't considered command line options to `tar`, `tar` is called with
 `--verbatim-files-from` option.
 
 
@@ -103,3 +110,19 @@ To ensure files starting with a dash aren't considered command line options to `
 * [Patrick Lehmann](https://GitHub.com/Paebbels) (Maintainer)
 * [Sven Köhler](https://GitHub.com/skoehler)
 * [and more...](https://GitHub.com/pyTooling/upload-artifact/graphs/contributors)
+
+### Credits
+
+**This action was inspired by and is based on:**
+ * [actions/upload-artifact#38 - upload-artifact does not retain artifact permissions (08. Sep. 2024)](https://github.com/actions/upload-artifact/issues/38#issuecomment-2336484584)
+ * [Gist: 
+rcdailey/download-tar-action.yml](https://gist.github.com/rcdailey/cd3437bb2c63647126aa5740824b2a4f)
+
+
+## License
+
+This GitHub Composite Action (source code) licensed under [The MIT License](LICENSE.md).
+
+---
+
+SPDX-License-Identifier: MIT

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
       Minimum 1 day.
       Maximum 90 days unless changed from the repository settings page.
       Optional. Defaults to repository settings.
-    type: integer
+    type: number
     required: false
   compression-level:
     description: |
@@ -49,7 +49,7 @@ inputs:
       The value can range from 0 to 9.
       For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.
       Optional. Default is '6'
-    type: integer
+    type: number
     required: false
     default: 6
   overwrite:

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,7 @@ runs:
         fi
         
         echo -n "Creating temporary tarball '${tarDirectory}${{ inputs.tarball-name }}' ... "
-        tar -cf "${tarDirectory}${{ inputs.tarball-name }}" "${filesFrom[@]}" <(print_files_unique "${PATTERNS[@]}")
+        tar -cf "${tarDirectory}${{ inputs.tarball-name }}" --owner=0 --group=0 "${filesFrom[@]}" <(print_files_unique "${PATTERNS[@]}")
         if [[ $? -ne 0 ]]; then
           echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,20 @@
-name: Upload (preserving) Artifact
+# The MIT License (MIT)
+#
+# Copyright © 2024 The pyTooling Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+name: Upload Artifact (Preserve File Permissions)
 branding:
   icon: upload
   color: yellow
@@ -9,7 +25,6 @@ inputs:
   name:
     description: | 
       Name of the artifact to upload.
-      Optional. Default is 'artifact'
     type: string
     required: false
     default: 'artifact'
@@ -21,7 +36,6 @@ inputs:
   path:
     description: |
       A file, directory or wildcard pattern that describes what to upload
-      Required.
     type: string
     required: true
   if-no-files-found:
@@ -31,7 +45,6 @@ inputs:
         warn: Output a warning but do not fail the action
         error: Fail the action with an error message
         ignore: Do not output any warnings or errors, the action does not fail
-      Optional. Default is 'warn'
     type: string
     required: false
     default: 'warn'
@@ -40,7 +53,7 @@ inputs:
       Duration after which artifact will expire in days. 0 means using default retention.
       Minimum 1 day.
       Maximum 90 days unless changed from the repository settings page.
-      Optional. Defaults to repository settings.
+      Defaults to repository settings.
     type: number
     required: false
   compression-level:
@@ -48,7 +61,6 @@ inputs:
       The level of compression for Zlib to be applied to the artifact archive.
       The value can range from 0 to 9.
       For large files that are not easily compressed, a value of 0 is recommended for significantly faster uploads.
-      Optional. Default is '6'
     type: number
     required: false
     default: 6
@@ -57,7 +69,6 @@ inputs:
       If true, an artifact with a matching name will be deleted before a new one is uploaded.
       If false, the action will fail if an artifact for the given name already exists.
       Does not fail if the artifact does not exist.
-      Optional. Default is 'false'
     type: boolean
     required: false
     default: false
@@ -66,7 +77,6 @@ inputs:
       Whether to include hidden files in the provided path in the artifact
       The file contents of any hidden files in the path should be validated before
       enabled this to avoid uploading sensitive information.
-      Optional. Default is 'false'
     type: boolean
     required: false
     default: false
@@ -84,7 +94,7 @@ outputs:
       URL to download an Artifact. Can be used in many scenarios such as linking to
       artifacts in issues or pull requests. Users must be logged-in in order for this
       URL to work. This URL is valid as long as the artifact has not expired or the
-      artifact, run or repository have not been deleted
+      artifact, run or repository have not been deleted.
     value: ${{ steps.upload.outputs.artifact-url }}
 
 runs:


### PR DESCRIPTION
# New Features

* Enhanced README
  * Documented input and output parameters.
  * Documented the usage.
  * Documented differences/fixes to `actions/upload-artifact`.
  * Documented pitfalls of `tar` on macOS.
* Added MIT license text.
* Added GitHub repository files.

# Changes

* Collect files in tarball with userid=0 and groupid=0.

# Bug Fixes

* Corrected data types in YAML